### PR TITLE
DLS-12731 | Integrate with internal-auth for api platform usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please ensure you reference the OGD Data Item matrix to ensure the right data it
 
 ### Running the service
 
-Ensure mongodb and service manager (for auth wizard and organisations-matching microservice) are running.
+Ensure mongodb and service manager (for auth wizard, internal-auth and organisations-matching microservice) are running.
 
 ```sm2 --start OVHO```
 
@@ -24,6 +24,56 @@ The service runs on port 9657 with:
 ```sbt run```
 
 Headers, endpoints, and example request bodies can be found in the documentation on [DevHub](https://developer.qa.tax.service.gov.uk/api-documentation/docs/api/service/organisations-matching-api/1.0).
+
+### Internal auth local testing
+
+Internal auth is wired via `conf/application.conf`:
+- `play.modules.enabled += "uk.gov.hmrc.internalauth.client.modules.InternalAuthModule"`
+- `microservice.services.internal-auth` (defaults to `http://localhost:8470`)
+
+For internal-auth first behaviour, call endpoints with an `Authorization` header. If internal-auth denies/errs, service 
+falls back to existing scope-based privileged auth checks. Following steps outline local verification:
+
+1. Start internal-auth via service manager (as part of `OVHO`):
+
+```bash
+sm2 --start OVHO
+```
+
+2. Create a token that allows access to API:
+
+```bash
+curl -i -X POST 'http://localhost:8470/test-only/token' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "token":"ia-allow-token",
+    "principal":"organisations-matching-api-local",
+    "permissions":[{"resourceType":"organisations-matching-api","resourceLocation":"*","actions":["READ"]}]
+  }'
+```
+
+3. Verify the token and permissions using commands from `internal-auth` [README](https://github.com/hmrc/internal-auth?tab=readme-ov-file#test-only-api), replacing the token with `ia-allow-token`.
+
+4. Call a missing record using the token, expected response is `404` (auth succeeds, record is missing):
+
+```bash
+MISSING_ID="90D91C50-5B47-4FD5-858C-AC7DC22EDB3D" (should be a valid guid otherwise it fails validation before auth)
+CORRELATION_ID="188e9400-b636-4a3b-80ba-230a8c72b92a"
+
+curl -i "http://localhost:9657/match-record/vat/$MISSING_ID" \
+  -H 'Authorization: Bearer ia-allow-token' \
+  -H 'Accept: application/vnd.hmrc.1.0+json' \
+  -H "CorrelationId: $CORRELATION_ID"
+```
+
+5. Call the same endpoint with an invalid token, expected response is `401`:
+
+```bash
+curl -i "http://localhost:9657/match-record/vat/$MISSING_ID" \
+  -H 'Authorization: Bearer invalid-token' \
+  -H 'Accept: application/vnd.hmrc.1.0+json' \
+  -H "CorrelationId: $CORRELATION_ID"
+```
 
 ### Running tests
 

--- a/app/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthHelper.scala
+++ b/app/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthHelper.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.organisationsmatchingapi.controllers
+
+import play.api.Configuration
+import play.api.Logger
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.internalauth.client.{BackendAuthComponents, Predicate as IAPredicate, Retrieval}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class InternalAuthHelper @Inject() (backendAuthComponents: BackendAuthComponents, configuration: Configuration) {
+
+  private val logger: Logger = play.api.Logger(this.getClass)
+
+  private val internalAuthPermission: IAPredicate = InternalAuthPermission.readPermission
+  private val internalAuthEnabled: Boolean = configuration.get[Boolean](InternalAuthHelper.InternalAuthFeatureFlag)
+
+  def isAuthorised(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): Future[Boolean] =
+    if (internalAuthEnabled) {
+      backendAuthComponents
+        .verify(Retrieval.hasPredicate(internalAuthPermission))
+        .map(_.contains(true))
+        .recover { case e =>
+          logger.warn("Internal auth failed, falling back to scopes auth", e)
+          false
+        }
+    } else {
+      logger.info("Internal auth disabled, falling back to scopes auth")
+      Future.successful(false)
+    }
+}
+
+object InternalAuthHelper {
+  val InternalAuthFeatureFlag: String = "features.internal-auth.enabled"
+}

--- a/app/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthPermission.scala
+++ b/app/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthPermission.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.organisationsmatchingapi.controllers
+
+import uk.gov.hmrc.internalauth.client.{IAAction, Predicate, Resource, ResourceLocation, ResourceType}
+
+object InternalAuthPermission {
+
+  private val resource = Resource(
+    resourceType = ResourceType("organisations-matching-api"),
+    resourceLocation = ResourceLocation("*")
+  )
+
+  val readPermission: Predicate.Permission =
+    Predicate.Permission(
+      resource = resource,
+      action = IAAction("READ")
+    )
+}

--- a/app/uk/gov/hmrc/organisationsmatchingapi/controllers/MatchingController.scala
+++ b/app/uk/gov/hmrc/organisationsmatchingapi/controllers/MatchingController.scala
@@ -35,6 +35,7 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class MatchingController @Inject() (
   val authConnector: AuthConnector,
+  val internalAuthHelper: InternalAuthHelper,
   cc: ControllerComponents,
   mcc: MessagesControllerComponents,
   scopeService: ScopesService,
@@ -58,16 +59,7 @@ class MatchingController @Inject() (
               .getHalLinks(matchId, None, authScopes, Some(List("getCorporationTaxMatch"))) ++ selfLink
           )
 
-          auditHelper.auditApiResponse(
-            correlationId.toString,
-            matchId.toString,
-            authScopes.mkString(","),
-            request,
-            selfLink.toString,
-            Some(response)
-          )
-
-          Ok(response)
+          auditApiResponse(response, correlationId.toString, matchId.toString, authScopes, selfLink.toString)
         }
       }
     } recover recoveryWithAudit(maybeCorrelationId(request), request.body.toString, self)
@@ -87,16 +79,7 @@ class MatchingController @Inject() (
               .getHalLinks(matchId, None, authScopes, Some(List("getSelfAssessmentMatch"))) ++ selfLink
           )
 
-          auditHelper.auditApiResponse(
-            correlationId.toString,
-            matchId.toString,
-            authScopes.mkString(","),
-            request,
-            selfLink.toString,
-            Some(response)
-          )
-
-          Ok(response)
+          auditApiResponse(response, correlationId.toString, matchId.toString, authScopes, selfLink.toString)
         }
       }
     } recover recoveryWithAudit(maybeCorrelationId(request), request.body.toString, self)
@@ -114,16 +97,7 @@ class MatchingController @Inject() (
           val data = toJson(MatchIdResponse(matchId))
           val response = Json.toJson(state(data) ++ halLinks ++ selfLink)
 
-          auditHelper.auditApiResponse(
-            correlationId.toString,
-            matchId.toString,
-            authScopes.mkString(","),
-            request,
-            selfLink.toString,
-            Some(response)
-          )
-
-          Ok(response)
+          auditApiResponse(response, correlationId.toString, matchId.toString, authScopes, selfLink.toString)
         }
       }
     } recover recoveryWithAudit(maybeCorrelationId(request), request.body.toString, self)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -35,6 +35,7 @@ play.http.errorHandler = "uk.gov.hmrc.organisationsmatchingapi.handlers.CustomEr
 # ~~~~
 # Additional play modules can be added here
 play.modules.enabled += "uk.gov.hmrc.organisationsmatchingapi.config.ConfigModule"
+play.modules.enabled += "uk.gov.hmrc.internalauth.client.modules.InternalAuthModule"
 
 # Session Timeout
 # ~~~~
@@ -135,6 +136,12 @@ microservice {
       port = 9658
     }
 
+    internal-auth {
+      protocol = http
+      host = localhost
+      port = 8470
+    }
+
     integration-framework {
       host = localhost
       port = 8443
@@ -145,6 +152,12 @@ microservice {
       }
       environment = isit
     }
+  }
+}
+
+features {
+  internal-auth {
+    enabled = true
   }
 }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,14 +3,15 @@ import sbt.*
 object AppDependencies {
   val hmrc = "uk.gov.hmrc"
   val playVersion = "play-30"
-  val hmrcMongoVersion = "2.10.0"
-  var bootstrapVersion = "10.4.0"
+  val hmrcMongoVersion = "2.12.0"
+  var bootstrapVersion = "10.5.0"
 
   val compile: Seq[ModuleID] = Seq(
     s"$hmrc.mongo" %% s"hmrc-mongo-$playVersion"    % hmrcMongoVersion,
     hmrc           %% s"play-hmrc-api-$playVersion" % "8.3.0",
     hmrc           %% s"play-hal-$playVersion"      % "4.1.0",
-    hmrc           %% s"crypto-json-$playVersion"   % "8.4.0"
+    hmrc           %% s"crypto-json-$playVersion"   % "8.4.0",
+    hmrc           %% s"internal-auth-client-$playVersion" % "4.3.0"
   )
 
   def test(scope: String = "test, it, component"): Seq[ModuleID] = Seq(

--- a/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthComponentSpec.scala
+++ b/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthComponentSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.uk.gov.hmrc.organisationsmatchingapi.controllers
+
+import component.uk.gov.hmrc.organisationsmatchingapi.controllers.stubs.{AuthStub, BaseSpec, InternalAuthStub}
+import play.api.test.Helpers.OK
+import scalaj.http.Http
+import uk.gov.hmrc.organisationsmatchingapi.domain.models.CtMatch
+import uk.gov.hmrc.organisationsmatchingapi.domain.ogd.CtMatchingRequest
+
+import java.util.UUID
+import scala.concurrent.Await.result
+
+class InternalAuthComponentSpec extends BaseSpec {
+
+  private val scopes: List[String] = List("read:organisations-matching-ho")
+
+  Feature("internal auth precedence and fallback") {
+    Scenario("internal auth success bypasses legacy auth") {
+      val matchId = UUID.randomUUID()
+      val ctMatch = CtMatch(
+        CtMatchingRequest("0123456789", "name", "line1", "postcode"),
+        matchId,
+        utr = Some("utr")
+      )
+
+      Given("internal auth authorises the token")
+      InternalAuthStub.willAuthorizeToken(authToken)
+
+      And("the match exists in cache")
+      result(mongoRepository.cache(matchId.toString, ctMatch), timeout)
+
+      When("the endpoint is invoked")
+      val response = Http(s"$serviceUrl/corporation-tax/$matchId")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
+
+      Then("the request succeeds and does not call legacy auth")
+      response.code mustBe OK
+      InternalAuthStub.verifyAuthRequestCount(expectedCount = 1)
+      AuthStub.verifyAuthoriseRequestCount(expectedCount = 0)
+    }
+
+    Scenario("internal auth denial falls back to legacy scope auth") {
+      val matchId = UUID.randomUUID()
+      val ctMatch = CtMatch(
+        CtMatchingRequest("0123456789", "name", "line1", "postcode"),
+        matchId,
+        utr = Some("utr")
+      )
+
+      Given("internal auth denies the token")
+      InternalAuthStub.willNotAuthorizeToken(authToken)
+
+      And("legacy auth allows the required scope")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, scopes)
+
+      And("the match exists in cache")
+      result(mongoRepository.cache(matchId.toString, ctMatch), timeout)
+
+      When("the endpoint is invoked")
+      val response = Http(s"$serviceUrl/corporation-tax/$matchId")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
+
+      Then("the request succeeds via fallback and both auth services were called")
+      response.code mustBe OK
+      InternalAuthStub.verifyAuthRequestCount(expectedCount = 1)
+      AuthStub.verifyAuthoriseRequestCount(expectedCount = 1)
+    }
+  }
+
+  Feature("internal auth feature flag") {
+    Scenario("when internal auth is disabled, request is authorised via legacy scopes auth only") {
+      val matchId = UUID.randomUUID()
+      val ctMatch = CtMatch(
+        CtMatchingRequest("0123456789", "name", "line1", "postcode"),
+        matchId,
+        utr = Some("utr")
+      )
+
+      Given("legacy auth allows the required scope")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, scopes)
+
+      And("the match exists in cache")
+      result(mongoRepository.cache(matchId.toString, ctMatch), timeout)
+
+      When("the endpoint is invoked against an app with internal auth disabled")
+      val response = withConfiguredServer("features.internal-auth.enabled" -> false) { disabledServiceUrl =>
+        Http(s"$disabledServiceUrl/corporation-tax/$matchId")
+          .headers(requestHeaders(acceptHeaderP1))
+          .asString
+      }
+
+      Then("the request succeeds, using legacy auth without calling internal auth")
+      response.code mustBe OK
+      InternalAuthStub.verifyAuthRequestCount(expectedCount = 0)
+      AuthStub.verifyAuthoriseRequestCount(expectedCount = 1)
+    }
+  }
+}

--- a/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/MatchedControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/MatchedControllerSpec.scala
@@ -449,12 +449,15 @@ class MatchedControllerSpec extends BaseSpec  {
   Feature("matched organisation") {
     Scenario("a valid request is made for an existing match id") {
       Given("A valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, scopes)
 
       And("A valid match exist")
       result(mongoRepository.cache(matchId.toString, saMatch), timeout)
 
       When("the API is invoked")
-      val response = Http(s"$serviceUrl/match-record/$matchId").asString
+      val response = Http(s"$serviceUrl/match-record/$matchId")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
 
       response.code shouldBe OK
 
@@ -465,11 +468,14 @@ class MatchedControllerSpec extends BaseSpec  {
 
     Scenario("a valid request is made for a match id that does not exist") {
       Given("A valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, scopes)
 
       And("A valid match does not exist")
 
       When("the API is invoked")
-      val response = Http(s"$serviceUrl/match-record/$matchId").asString
+      val response = Http(s"$serviceUrl/match-record/$matchId")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
 
       response.code shouldBe NOT_FOUND
 
@@ -481,12 +487,15 @@ class MatchedControllerSpec extends BaseSpec  {
 
     Scenario("a valid request is made for an invalid match id") {
       Given("A valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, scopes)
 
       And("A valid match exist")
       result(mongoRepository.cache(matchId.toString, saMatch), timeout)
 
       When("the API is invoked")
-      val response = Http(s"$serviceUrl/match-record/foo").asString
+      val response = Http(s"$serviceUrl/match-record/foo")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
 
       response.code shouldBe BAD_REQUEST
 
@@ -495,17 +504,33 @@ class MatchedControllerSpec extends BaseSpec  {
         "message" -> "matchId format is invalid"
       )
     }
+
+    Scenario("not authorized") {
+      Given("an invalid privileged Auth bearer token")
+      AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, scopes)
+
+      When("the API is invoked")
+      val response = Http(s"$serviceUrl/match-record/$matchId")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
+
+      Then("the response status should be 401 (unauthorized)")
+      response.code shouldBe UNAUTHORIZED
+    }
   }
 
   Feature("matched organisation vat") {
     Scenario("a valid request is made for an existing match id") {
       Given("A valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, scopes)
 
       And("A valid match exist")
       result(mongoRepository.cache(matchId.toString, vatMatch), timeout)
 
       When("the API is invoked")
-      val response = Http(s"$serviceUrl/match-record/vat/$matchId").headers(acceptHeaderP1).asString
+      val response = Http(s"$serviceUrl/match-record/vat/$matchId")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
 
       response.code shouldBe OK
 
@@ -516,11 +541,14 @@ class MatchedControllerSpec extends BaseSpec  {
 
     Scenario("a valid request is made for a match id that does not exist") {
       Given("A valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, scopes)
 
       And("A valid match does not exist")
 
       When("the API is invoked")
-      val response = Http(s"$serviceUrl/match-record/vat/$matchId").asString
+      val response = Http(s"$serviceUrl/match-record/vat/$matchId")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
 
       response.code shouldBe NOT_FOUND
 
@@ -532,12 +560,15 @@ class MatchedControllerSpec extends BaseSpec  {
 
     Scenario("a valid request is made for an invalid match id") {
       Given("A valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, scopes)
 
       And("A valid match exist")
       result(mongoRepository.cache(matchId.toString, saMatch), timeout)
 
       When("the API is invoked")
-      val response = Http(s"$serviceUrl/match-record/vat/foo").asString
+      val response = Http(s"$serviceUrl/match-record/vat/foo")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
 
       response.code shouldBe BAD_REQUEST
 
@@ -545,6 +576,19 @@ class MatchedControllerSpec extends BaseSpec  {
         "code" -> "INVALID_REQUEST",
         "message" -> "matchId format is invalid"
       )
+    }
+
+    Scenario("not authorized") {
+      Given("an invalid privileged Auth bearer token")
+      AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, scopes)
+
+      When("the API is invoked")
+      val response = Http(s"$serviceUrl/match-record/vat/$matchId")
+        .headers(requestHeaders(acceptHeaderP1))
+        .asString
+
+      Then("the response status should be 401 (unauthorized)")
+      response.code shouldBe UNAUTHORIZED
     }
   }
 

--- a/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/stubs/AuthStub.scala
+++ b/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/stubs/AuthStub.scala
@@ -96,4 +96,7 @@ object AuthStub extends MockHost(22000) {
         .willReturn(aResponse()
           .withStatus(Status.UNAUTHORIZED)
           .withHeader(HeaderNames.WWW_AUTHENTICATE, """MDTP detail="Bearer token is missing or not authorized"""")))
+
+  def verifyAuthoriseRequestCount(expectedCount: Int): Unit =
+    server.verify(expectedCount, postRequestedFor(urlEqualTo("/auth/authorise")))
 }

--- a/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/stubs/IfStub.scala
+++ b/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/stubs/IfStub.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.organisationsmatchingapi.domain.integrationframework.ct.IfCor
 import uk.gov.hmrc.organisationsmatchingapi.domain.integrationframework.sa.IfSaTaxpayerDetails
 import uk.gov.hmrc.organisationsmatchingapi.domain.integrationframework.vat.IfVatCustomerInformation
 
-object IfStub extends MockHost(8443) {
+object IfStub extends MockHost(22002) {
 
 
   def searchCorpTaxCompanyDetails(crn: String, ifCorpTaxCompanyDetails: IfCorpTaxCompanyDetails): Unit =

--- a/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/stubs/InternalAuthStub.scala
+++ b/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/stubs/InternalAuthStub.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.uk.gov.hmrc.organisationsmatchingapi.controllers.stubs
+
+import play.api.http.HeaderNames.AUTHORIZATION
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+
+object InternalAuthStub extends MockHost(22003) {
+
+  def willAuthorizeToken(authBearerToken: String): StubMapping =
+    mock.register(
+      post(urlEqualTo("/internal-auth/auth"))
+        .withHeader(AUTHORIZATION, equalTo(authBearerToken))
+        .willReturn(okJson("""{ "retrievals": [ true ] }"""))
+    )
+
+  def willNotAuthorizeToken(authBearerToken: String): StubMapping =
+    mock.register(
+      post(urlEqualTo("/internal-auth/auth"))
+        .withHeader(AUTHORIZATION, equalTo(authBearerToken))
+        .willReturn(forbidden())
+    )
+
+  def verifyAuthRequestCount(expectedCount: Int): Unit =
+    server.verify(expectedCount, postRequestedFor(urlEqualTo("/internal-auth/auth")))
+}

--- a/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/stubs/MatchingStub.scala
+++ b/test/component/uk/gov/hmrc/organisationsmatchingapi/controllers/stubs/MatchingStub.scala
@@ -19,7 +19,7 @@ package component.uk.gov.hmrc.organisationsmatchingapi.controllers.stubs
 import com.github.tomakehurst.wiremock.client.WireMock._
 import play.api.http.Status
 
-object MatchingStub extends MockHost(9658) {
+object MatchingStub extends MockHost(22001) {
 
   def willReturnCtMatch(correlationId: String): Unit =
     mock.register(

--- a/test/unit/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthHelperSpec.scala
+++ b/test/unit/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthHelperSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.uk.gov.hmrc.organisationsmatchingapi.controllers
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.BDDMockito.`given`
+import org.mockito.Mockito.{atLeastOnce, never, verify}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
+import play.api.http.Status.UNAUTHORIZED
+import play.api.mvc.ControllerComponents
+import play.api.test.Helpers
+import uk.gov.hmrc.http.{Authorization, HeaderCarrier}
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.internalauth.client.BackendAuthComponents
+import uk.gov.hmrc.internalauth.client.test.{BackendAuthComponentsStub, StubBehaviour}
+import uk.gov.hmrc.organisationsmatchingapi.controllers.InternalAuthHelper
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.Await
+
+class InternalAuthHelperSpec extends AnyWordSpec with Matchers with MockitoSugar {
+
+  private implicit val cc: ControllerComponents = Helpers.stubControllerComponents()
+  private val internalAuthTokenHeaderCarrier: HeaderCarrier =
+    HeaderCarrier(authorization = Some(Authorization("Bearer internal-token")))
+
+  private def helperWith(
+    enabled: Boolean,
+    stubBehaviour: StubBehaviour
+  ): InternalAuthHelper = {
+    val backendAuthComponents: BackendAuthComponents = BackendAuthComponentsStub(stubBehaviour)
+    new InternalAuthHelper(
+      backendAuthComponents,
+      Configuration(InternalAuthHelper.InternalAuthFeatureFlag -> enabled)
+    )
+  }
+
+  "InternalAuthHelper" should {
+    "skip internal auth checks when disabled by config" in {
+      val mockInternalAuthBehaviour: StubBehaviour = mock[StubBehaviour]
+      val helper = helperWith(enabled = false, mockInternalAuthBehaviour)
+      implicit val hc: HeaderCarrier = HeaderCarrier()
+
+      val result = Await.result(helper.isAuthorised, 2.seconds)
+
+      result shouldBe false
+      verify(mockInternalAuthBehaviour, never()).stubAuth(any(), any())
+    }
+
+    "return true when enabled and internal auth authorises" in {
+      val mockInternalAuthBehaviour: StubBehaviour = mock[StubBehaviour]
+      `given`(mockInternalAuthBehaviour.stubAuth(any(), any())).willReturn(Future.successful(true))
+      val helper = helperWith(enabled = true, mockInternalAuthBehaviour)
+      implicit val hc: HeaderCarrier = internalAuthTokenHeaderCarrier
+
+      val result = Await.result(helper.isAuthorised, 2.seconds)
+
+      result shouldBe true
+      verify(mockInternalAuthBehaviour, atLeastOnce()).stubAuth(any(), any())
+    }
+
+    "return false when enabled and internal auth denies authorisation" in {
+      val mockInternalAuthBehaviour: StubBehaviour = mock[StubBehaviour]
+      `given`(mockInternalAuthBehaviour.stubAuth(any(), any())).willReturn(Future.successful(false))
+      val helper = helperWith(enabled = true, mockInternalAuthBehaviour)
+      implicit val hc: HeaderCarrier = internalAuthTokenHeaderCarrier
+
+      val result = Await.result(helper.isAuthorised, 2.seconds)
+
+      result shouldBe false
+      verify(mockInternalAuthBehaviour, atLeastOnce()).stubAuth(any(), any())
+    }
+
+    "return false when enabled and internal auth throws an error" in {
+      val mockInternalAuthBehaviour: StubBehaviour = mock[StubBehaviour]
+      `given`(mockInternalAuthBehaviour.stubAuth(any(), any()))
+        .willReturn(Future.failed(UpstreamErrorResponse("Unauthorized", UNAUTHORIZED)))
+      val helper = helperWith(enabled = true, mockInternalAuthBehaviour)
+      implicit val hc: HeaderCarrier = internalAuthTokenHeaderCarrier
+
+      val result = Await.result(helper.isAuthorised, 2.seconds)
+
+      result shouldBe false
+      verify(mockInternalAuthBehaviour, atLeastOnce()).stubAuth(any(), any())
+    }
+  }
+}

--- a/test/unit/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthPermissionSpec.scala
+++ b/test/unit/uk/gov/hmrc/organisationsmatchingapi/controllers/InternalAuthPermissionSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.uk.gov.hmrc.organisationsmatchingapi.controllers
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+
+import uk.gov.hmrc.organisationsmatchingapi.controllers.InternalAuthPermission
+
+import uk.gov.hmrc.internalauth.client.{IAAction, Predicate, Resource, ResourceLocation, ResourceType}
+
+class InternalAuthPermissionSpec extends AnyWordSpec with Matchers {
+
+  given CanEqual[Predicate.Permission, Predicate.Permission] = CanEqual.derived
+
+  "InternalAuthPermission.readPermission" should {
+    "build the expected internal-auth permission predicate" in {
+      InternalAuthPermission.readPermission shouldBe Predicate.Permission(
+        resource = Resource(
+          resourceType = ResourceType("organisations-matching-api"),
+          resourceLocation = ResourceLocation("*")
+        ),
+        action = IAAction("READ")
+      )
+    }
+  }
+}

--- a/test/unit/uk/gov/hmrc/organisationsmatchingapi/services/MatchingServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/organisationsmatchingapi/services/MatchingServiceSpec.scala
@@ -181,6 +181,7 @@ class MatchingServiceSpec extends AnyWordSpec with SpecBase with Matchers with M
       `given`(mockMatchingConnector.matchCycleVat(eqTo(matchId), eqTo(UUID.randomUUID()), eqTo(orgsMatchingRequest))(using any(), any()))
         .willReturn(Future.successful(Json.toJson("test")))
       `given`(mockCacheService.cacheVatVrn(VatMatch(matchId, Some(request.vrn))))
+        .willReturn(Future.successful(InsertResult.InsertSucceeded))
     }
   }
 }


### PR DESCRIPTION
- Add internal-auth-client and READ permission for resources, for api-platform access
- Failure on internal-auth valid check does privileged scope validation
- internal-auth functionality behind feature-flag
- Improve test coverage for existing privileged auth and add cases for internal-auth